### PR TITLE
flatten out data to support key expiration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-delayed-response",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "automatically provides polling responses for long running operations",
   "main": "src/index.js",
   "scripts": {

--- a/src/lib/createClient.js
+++ b/src/lib/createClient.js
@@ -20,7 +20,8 @@ function createClient(options) {
     },
     set(key, value, callback, maxAge) {
       const created = !cache.has(key);
-      cache.set(key, value, maxAge);
+      // maxAge for lru-cache is defined in ms
+      cache.set(key, value, maxAge * 1000);
       if (callback) {
         callback(null, created);
       }

--- a/src/lib/createClient.js
+++ b/src/lib/createClient.js
@@ -13,9 +13,9 @@ function createClient(options) {
         throw Error('No callback supplied to get.');
       }
       if (!cache.has(key)) {
-        callback(null, null, null);
+        callback(null, null);
       } else {
-        callback(null, null, cache.get(key));
+        callback(null, cache.get(key));
       }
     },
     set(key, value, callback, maxAge) {

--- a/src/lib/createClient.js
+++ b/src/lib/createClient.js
@@ -8,23 +8,23 @@ const LRU = require('lru-cache');
 function createClient(options) {
   const cache = LRU(options);
   return {
-    hget(key, field, callback) {
-      if (!callback) {
-        throw Error('No callback supplied to hget.');
+    get(key, callback) {
+      if (!callback || typeof callback !== 'function') {
+        throw Error('No callback supplied to get.');
       }
-      if (!cache.has(field)) {
-        callback(null, null);
+      if (!cache.has(key)) {
+        callback.call(null, null, null);
       } else {
-        callback(null, cache.get(field));
+        callback.call(null, null, cache.get(key));
       }
     },
-    hset(key, field, value, callback) {
-      const created = !cache.has(field);
-      cache.set(field, value);
+    set(key, value, callback, maxAge) {
+      const created = !cache.has(key);
+      cache.set(key, value, maxAge);
       if (callback) {
         callback(null, created);
       }
-    },
+    }
   };
 }
 

--- a/src/lib/createClient.js
+++ b/src/lib/createClient.js
@@ -13,9 +13,9 @@ function createClient(options) {
         throw Error('No callback supplied to get.');
       }
       if (!cache.has(key)) {
-        callback.call(null, null, null);
+        callback(null, null, null);
       } else {
-        callback.call(null, null, cache.get(key));
+        callback(null, null, cache.get(key));
       }
     },
     set(key, value, callback, maxAge) {

--- a/test/createClient.js
+++ b/test/createClient.js
@@ -5,15 +5,14 @@ const assert = require('assert');
 describe('Test createClient', () => {
   const appKey = shortid.generate();
   const client = createClient();
-  const field = shortid.generate();
   const value = {
     value: shortid.generate(),
   };
 
   it('should save object by id', (done) => {
-    client.hset(appKey, field, value);
-    client.hset(appKey, field, value, () => {
-      client.hget(appKey, field, (err, res) => {
+    client.set(appKey, value);
+    client.set(appKey, value, () => {
+      client.get(appKey, (err, res) => {
         assert.deepEqual(res, value);
         done();
       });
@@ -21,13 +20,13 @@ describe('Test createClient', () => {
   });
 
   it('should respond null if key does not exist', (done) => {
-    client.hget(appKey, 'null', (err, res) => {
+    client.get('null', (err, res) => {
       assert(res === null);
       done();
     });
   });
 
-  it('should throw error if callback is not supplied to hget', () => {
-    assert.throws(() => client.hget(appKey, field), /callback/);
+  it('should throw error if callback is not supplied to get', () => {
+    assert.throws(() => client.get(appKey), /callback/);
   });
 });


### PR DESCRIPTION
Overview of changes:
-updated cacheClient to use redis set/get vs. hset/hget to support key expiration
-updated set call when using `lru-cache` to support field expiration (maxAge)